### PR TITLE
Always log errors

### DIFF
--- a/genericr.go
+++ b/genericr.go
@@ -141,6 +141,9 @@ func (l Logger) WithCallerDepth(depth int) Logger {
 }
 
 func (l Logger) Info(msg string, kvList ...interface{}) {
+	if !l.Enabled() {
+		return
+	}
 	l.logMessage(nil, msg, kvList)
 }
 
@@ -191,9 +194,6 @@ func (l Logger) WithValues(kvList ...interface{}) logr.Logger {
 
 // logMessage implements the actual logging for .Info() and .Error()
 func (l Logger) logMessage(err error, msg string, kvList []interface{}) {
-	if !l.Enabled() {
-		return
-	}
 	var out []interface{}
 	if len(l.values) == 0 && len(kvList) > 0 {
 		out = kvList

--- a/genericr_test.go
+++ b/genericr_test.go
@@ -117,6 +117,12 @@ func TestLogger_Table(t *testing.T) {
 			`[0]  "help" error="some error"`,
 		},
 		{
+			func() {
+				log.WithVerbosity(3).V(4).Error(errors.New("some error"), "errors are always logged")
+			},
+			`[4]  "errors are always logged" error="some error"`,
+		},
+		{
 			f: func() {
 				log.WithValues(
 					"int", 42,


### PR DESCRIPTION
This is a nice little library. Thanks for creating it. However, in its current behavior, it is of no use to me as I expect error messages to be logged always. This assumption gets supported by https://github.com/go-logr/stdr/blob/2563e58/stdr.go#L163.