### PR TITLE
Adhere to logr.CallDepthLogSink

### DIFF
--- a/caller_test.go
+++ b/caller_test.go
@@ -1,8 +1,10 @@
 package genericr_test
 
-import "github.com/go-logr/logr"
+type infoLogger interface {
+	Info(msg string, keysAndValues ...interface{})
+}
 
 // This is indirectly tested by calling this function
-func logSomethingFromOtherFile(log logr.Logger) {
+func logSomethingFromOtherFile(log infoLogger) {
 	log.Info("test caller")
 }

--- a/genericr.go
+++ b/genericr.go
@@ -131,11 +131,8 @@ func (l LogSink) WithCaller(enabled bool) LogSink {
 	return l
 }
 
-// WithCallerDepth adjusts the caller depth. This is useful is the caller uses
-// a custom wrapper to log messages with extra info.
-// To actually do caller lookups, those have to be enabled with .WithCaller(true).
-// This is not part of the logr interface, so you can only use this on the root object.
-func (l LogSink) WithCallerDepth(depth int) LogSink {
+// WithCallDepth implements logr.CallDepthLogSink.
+func (l LogSink) WithCallDepth(depth int) logr.LogSink {
 	l.depth += depth
 	return l
 }
@@ -221,9 +218,9 @@ func (l LogSink) logMessage(level int, err error, msg string, kvList []interface
 	})
 }
 
-// Check that we indeed implement the logr.LogSink interface
+// Check that we indeed implement the logr.LogSink and logr.CallDepthLogSink interfaces.
 var _ logr.LogSink = LogSink{}
-var _ logr.LogSink = LogSink{}
+var _ logr.CallDepthLogSink = LogSink{}
 
 // Helper functions below
 

--- a/genericr_test.go
+++ b/genericr_test.go
@@ -196,7 +196,7 @@ func TestLogger_WithCallDepth(t *testing.T) {
 			fname, last.Caller.File, last.Caller.Line)
 	}
 	if last.CallerDepth != 5 {
-		t.Errorf("Caller depth: expected 4, got %d", last.CallerDepth)
+		t.Errorf("Caller depth: expected 5, got %d", last.CallerDepth)
 	}
 }
 


### PR DESCRIPTION
Hi there. Thank you for this library, it's allowing me to create custom logr sinks quite easily.

I noticed that the LogSink supports arbitrary call depth through the WithCallerDepth function. This seems to be in line with the logr.CallDepthLogSink except that the naming is different. This PR fixes that naming and makes the LogSink adhere to the logr.CallDepthLogSink interface. This will allow logr.Logger to leverage this functionality: https://github.com/go-logr/logr/blob/master/logr.go#L336

I also noticed a duplicated type check. I replaced one of those with a new check for logr.CallDepthLogSink.

To be able to test the WithCallDepth function I replaced the logr.Logger type in caller_test.go with a small interface.

